### PR TITLE
Add algorithm list page

### DIFF
--- a/algo-list.css
+++ b/algo-list.css
@@ -1,0 +1,52 @@
+.algo-page {
+    padding: 20px;
+}
+
+.algo-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.algo-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+}
+
+.algo-table th,
+.algo-table td {
+    border: 1px solid #dee2e6;
+    padding: 8px;
+    text-align: center;
+}
+
+.algo-table th {
+    background-color: #f8f9fa;
+}
+
+.action-icon-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    margin: 0 2px;
+    font-size: 14px;
+}
+
+.action-icon-btn.run {
+    color: #28a745;
+}
+
+.action-icon-btn.edit {
+    color: #007bff;
+}
+
+.action-icon-btn.delete {
+    color: #dc3545;
+}
+
+.action-icon-btn:hover {
+    opacity: 0.8;
+}

--- a/algo-list.html
+++ b/algo-list.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Danh sách Algo</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="algo-list.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-p+1RqYTxNOLXgq0fsE4zMDQLWcVFOPJz1D8SSsPyozJzDPbpe2T19ZLxNblLJjRwvxw9Y+QSIOcoPqW9J5XhMg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body>
+    <div class="algo-page">
+        <div class="algo-header">
+            <h2>Danh sách algo</h2>
+            <button id="authorize-algo-btn" class="action-btn primary">
+                <i class="fa fa-plus"></i> Authorize Algo
+            </button>
+        </div>
+        <table class="algo-table">
+            <thead>
+                <tr>
+                    <th>STT</th>
+                    <th>Tên</th>
+                    <th>Mã</th>
+                    <th>Nền tảng</th>
+                    <th>Winrate</th>
+                    <th>MDD</th>
+                    <th>Lợi nhuận</th>
+                    <th>Tăng/giảm</th>
+                    <th>Thao tác</th>
+                </tr>
+            </thead>
+            <tbody id="algo-table-body"></tbody>
+        </table>
+    </div>
+    <script src="algo-list.js"></script>
+</body>
+</html>

--- a/algo-list.js
+++ b/algo-list.js
@@ -1,0 +1,54 @@
+const algorithms = [
+    {
+        name: "Boppo_Canh",
+        code: "VN30F1M",
+        platform: "MB",
+        winrate: "55%",
+        mdd: "-8%",
+        profit: "325 điểm",
+        change: "+12%"
+    },
+    {
+        name: "Boppo_Canh_buy_sell",
+        code: "VN30F1M",
+        platform: "MB",
+        winrate: "63%",
+        mdd: "-5%",
+        profit: "285 điểm",
+        change: "+8%"
+    },
+    {
+        name: "Strategy Demo",
+        code: "VNM",
+        platform: "HSX",
+        winrate: "60%",
+        mdd: "-10%",
+        profit: "40%",
+        change: "+30%"
+    }
+];
+
+function renderAlgoTable() {
+    const tbody = document.getElementById('algo-table-body');
+    algorithms.forEach((algo, idx) => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td>${idx + 1}</td>
+            <td>${algo.name}</td>
+            <td>${algo.code}</td>
+            <td>${algo.platform}</td>
+            <td>${algo.winrate}</td>
+            <td>${algo.mdd}</td>
+            <td>${algo.profit}</td>
+            <td>${algo.change}</td>
+            <td>
+                <button class="action-icon-btn run" title="Run"><i class="fa fa-play"></i></button>
+                <button class="action-icon-btn edit" title="Edit"><i class="fa fa-edit"></i></button>
+                <button class="action-icon-btn delete" title="Delete"><i class="fa fa-trash"></i></button>
+            </td>
+        `;
+        tbody.appendChild(tr);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', renderAlgoTable);

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
                  <div class="strategy-selector">
                     <button class="tool-button" id="strategy-sma-cross-btn">Chạy SMA Cross</button>
                     <button class="tool-button" id="strategy-builder-btn">Strategy Builder</button>
-                </div>
+                    <button class="tool-button" onclick="window.location.href='algo-list.html'">Danh sách Algo</button>
+</div>
                 <div class="tools-selector">
                 <div class="indicator-menu">
                     <button class="tool-button" id="indicator-menu-btn">Chỉ báo</button>


### PR DESCRIPTION
## Summary
- add standalone algo-list page with sample algorithm data and action icons
- style algo list table and controls
- link chart page to new list page

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac2d61bc408321ad99e9a101a196ce