### PR TITLE
feat: integrate backend backtest

### DIFF
--- a/src/core/DataProvider.js
+++ b/src/core/DataProvider.js
@@ -115,4 +115,31 @@ class DataProvider {
         }
     }
     // ▲▲▲ KẾT THÚC THÊM MỚI ▲▲▲
+
+    // ▼▼▼ THÊM MỚI HÀM NÀY ▼▼▼
+    /**
+     * Gọi API backtest ở backend.
+     * @param {Object} config Cấu hình chiến lược và dữ liệu giá.
+     * @returns {Promise<Object|null>} Kết quả backtest hoặc null nếu lỗi.
+     */
+    async runBacktest(config) {
+        const url = `${API_BASE_URL}/api/backtest`;
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(config)
+            });
+            if (!response.ok) {
+                throw new Error(`Lỗi server khi backtest: ${response.status}`);
+            }
+            return await response.json();
+        } catch (error) {
+            console.error('Lỗi khi gọi API backtest:', error);
+            return null;
+        }
+    }
+    // ▲▲▲ KẾT THÚC THÊM MỚI ▲▲▲
 }


### PR DESCRIPTION
## Summary
- add DataProvider.runBacktest to call new backend endpoint
- trigger backend backtests from Strategy Builder and surface metrics

## Testing
- `python -m py_compile backend/server.py`
- `node --check src/core/DataProvider.js`
- `node --check src/pages/strategy-builder.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac9216cf908321863b79e36660b0dd