### PR TITLE
Add navigation menu and fix algo metrics

### DIFF
--- a/algo-list.html
+++ b/algo-list.html
@@ -9,6 +9,20 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-p+1RqYTxNOLXgq0fsE4zMDQLWcVFOPJz1D8SSsPyozJzDPbpe2T19ZLxNblLJjRwvxw9Y+QSIOcoPqW9J5XhMg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
 <body>
+    <header class="header">
+        <div class="left-header">
+            <div class="symbol-info">
+                <strong>Algo Manager</strong>
+                <span>Quản lý chiến lược</span>
+            </div>
+        </div>
+        <div class="right-header">
+            <div class="strategy-selector">
+                <button class="tool-button" onclick="window.location.href='index.html'">Biểu đồ</button>
+                <button class="tool-button" id="strategy-builder-btn">Strategy Builder</button>
+            </div>
+        </div>
+    </header>
     <div class="algo-page">
         <div class="algo-header">
             <h2>Danh sách algo</h2>

--- a/src/pages/algo-list.js
+++ b/src/pages/algo-list.js
@@ -146,5 +146,6 @@ document.addEventListener('DOMContentLoaded', () => {
             algoList.algorithms.push(entry);
         }
         algoList.render();
+        algoList.saveToLocalStorage();
     });
 });

--- a/src/pages/strategy-builder.js
+++ b/src/pages/strategy-builder.js
@@ -202,7 +202,9 @@ class StrategyBuilderUI {
                   const m = result.metrics;
                   const win = (m.winrate * 100).toFixed(2) + '%';
                   const mdd = '-' + (m.max_drawdown * 100).toFixed(2) + '%';
-                  const profit = (m.total_return * 100).toFixed(2) + '%';
+                  const profitPercent = (m.total_return * 100).toFixed(2);
+                  const profit = profitPercent + '%';
+                  const change = (m.total_return >= 0 ? '+' : '') + profitPercent + '%';
                   alert(`Backtest hoàn tất!\nWinrate: ${win}\nMDD: ${mdd}\nLợi nhuận: ${profit}`);
                   this.editingStrategy = {
                       ...config,
@@ -211,7 +213,7 @@ class StrategyBuilderUI {
                       winrate: win,
                       mdd: mdd,
                       profit: profit,
-                      change: profit
+                      change: change
                   };
               } else {
                   alert('Backtest không trả về kết quả hợp lệ.');


### PR DESCRIPTION
## Summary
- add top navigation to the algorithm list page
- capture backtest metrics with signed change values
- persist saved strategies and their metrics

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1ad519e48321b989fa1fcbd5773b