### PR TITLE
Add algo detail page with chart and overview sidebar

### DIFF
--- a/algo-detail.html
+++ b/algo-detail.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chi tiết Algo</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/algo-detail.css">
+</head>
+<body>
+    <div class="algo-container">
+        <main id="chart-area"></main>
+        <aside class="algo-sidebar">
+            <h2>Tổng quan</h2>
+            <ul class="overview-list">
+                <li>Winrate: <span id="overview-winrate">--%</span></li>
+                <li>MDD: <span id="overview-mdd">--%</span></li>
+                <li>Lợi nhuận: <span id="overview-profit">--</span></li>
+            </ul>
+        </aside>
+    </div>
+
+    <script src="https://unpkg.com/lightweight-charts@4.1.0/dist/lightweight-charts.standalone.production.js"></script>
+    <script src="src/core/StrategyEngine.js"></script>
+    <script src="src/core/DataProvider.js"></script>
+    <script src="src/pages/algo-detail.js"></script>
+</body>
+</html>

--- a/css/algo-detail.css
+++ b/css/algo-detail.css
@@ -1,0 +1,26 @@
+.algo-container {
+    display: flex;
+    height: 100vh;
+}
+
+#chart-area {
+    flex: 1;
+    background-color: white;
+}
+
+.algo-sidebar {
+    width: 280px;
+    background-color: white;
+    padding: 15px;
+    font-size: 0.9em;
+}
+
+.overview-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.overview-list li {
+    margin-bottom: 8px;
+}

--- a/src/pages/algo-detail.js
+++ b/src/pages/algo-detail.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const chartArea = document.getElementById('chart-area');
+    const chart = LightweightCharts.createChart(chartArea, {
+        width: chartArea.clientWidth,
+        height: chartArea.clientHeight,
+    });
+
+    const dataProvider = new DataProvider();
+    const strategyEngine = new StrategyEngine(chart, dataProvider);
+});


### PR DESCRIPTION
## Summary
- Add algo-detail page featuring chart area and overview sidebar
- Include dedicated styles and scripts for algo details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad21bab2f483218704030b6974f037