### PR TITLE
Add algo detail page with chart and overview sidebar

### DIFF
--- a/algo-detail.html
+++ b/algo-detail.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chi tiết Algo</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/algo-detail.css">
+</head>
+<body>
+    <div class="algo-container">
+        <main id="chart-area"></main>
+        <aside class="algo-sidebar">
+            <h2>Tổng quan</h2>
+            <ul class="overview-list">
+                <li>Winrate: <span id="overview-winrate">--%</span></li>
+                <li>MDD: <span id="overview-mdd">--%</span></li>
+                <li>Lợi nhuận: <span id="overview-profit">--</span></li>
+            </ul>
+        </aside>
+    </div>
+
+    <script src="https://unpkg.com/lightweight-charts@4.1.0/dist/lightweight-charts.standalone.production.js"></script>
+    <script src="src/core/StrategyEngine.js"></script>
+    <script src="src/core/DataProvider.js"></script>
+    <script src="src/pages/algo-detail.js"></script>
+</body>
+</html>

--- a/css/algo-detail.css
+++ b/css/algo-detail.css
@@ -1,0 +1,26 @@
+.algo-container {
+    display: flex;
+    height: 100vh;
+}
+
+#chart-area {
+    flex: 1;
+    background-color: white;
+}
+
+.algo-sidebar {
+    width: 280px;
+    background-color: white;
+    padding: 15px;
+    font-size: 0.9em;
+}
+
+.overview-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.overview-list li {
+    margin-bottom: 8px;
+}

--- a/src/pages/algo-detail.js
+++ b/src/pages/algo-detail.js
@@ -1,0 +1,45 @@
+document.addEventListener('DOMContentLoaded', async function () {
+    // Lấy thông tin algo đã chọn từ localStorage
+    let selectedAlgo = null;
+    try {
+        selectedAlgo = JSON.parse(localStorage.getItem('selectedAlgo')) || null;
+    } catch (err) {
+        console.error('Không thể đọc dữ liệu algo đã chọn:', err);
+    }
+
+    if (selectedAlgo) {
+        document.getElementById('overview-winrate').textContent = selectedAlgo.winrate || '--';
+        document.getElementById('overview-mdd').textContent = selectedAlgo.mdd || '--';
+        document.getElementById('overview-profit').textContent = selectedAlgo.profit || '--';
+    }
+
+    const symbol = (selectedAlgo && selectedAlgo.code) ? selectedAlgo.code : 'VNINDEX';
+
+    const chartArea = document.getElementById('chart-area');
+    const chart = LightweightCharts.createChart(chartArea, {
+        autoSize: true,
+        layout: { background: { color: '#ffffff' }, textColor: '#333' },
+        grid: { vertLines: { color: '#f0f3f5' }, horzLines: { color: '#f0f3f5' } },
+        timeScale: { borderColor: '#ddd', timeVisible: true, secondsVisible: false, rightOffset: 50 }
+    });
+
+    const mainSeries = chart.addCandlestickSeries({
+        upColor: '#26a69a',
+        downColor: '#ef5350',
+        borderVisible: false,
+        wickUpColor: '#26a69a',
+        wickDownColor: '#ef5350'
+    });
+
+    const dataProvider = new DataProvider();
+    const strategyEngine = new StrategyEngine(chart, mainSeries);
+
+    try {
+        const data = await dataProvider.getHistory(symbol, 'D');
+        if (data && data.length) {
+            mainSeries.setData(data);
+        }
+    } catch (error) {
+        console.error('Không thể tải dữ liệu biểu đồ:', error);
+    }
+});


### PR DESCRIPTION
## Summary
- Add algo-detail page featuring chart area and overview sidebar
- Include dedicated styles and scripts for algo details
- Load selected algo's data and populate chart and overview panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad21bab2f483218704030b6974f037