### PR TITLE
feat: enhance algo detail page with indicators

### DIFF
--- a/src/pages/algo-detail.js
+++ b/src/pages/algo-detail.js
@@ -1,12 +1,22 @@
 document.addEventListener('DOMContentLoaded', async function () {
-    // Lấy thông tin algo đã chọn từ localStorage
+    // Lấy tên algo từ URL hoặc localStorage
+    const params = new URLSearchParams(window.location.search);
+    const algoName = params.get('name');
+
     let selectedAlgo = null;
     try {
-        selectedAlgo = JSON.parse(localStorage.getItem('selectedAlgo')) || null;
+        if (algoName) {
+            const saved = JSON.parse(localStorage.getItem('savedStrategies') || '[]');
+            selectedAlgo = saved.find(s => s.name === algoName) || null;
+        }
+        if (!selectedAlgo) {
+            selectedAlgo = JSON.parse(localStorage.getItem('selectedAlgo')) || null;
+        }
     } catch (err) {
         console.error('Không thể đọc dữ liệu algo đã chọn:', err);
     }
 
+    // Hiển thị tổng quan
     if (selectedAlgo) {
         document.getElementById('overview-winrate').textContent = selectedAlgo.winrate || '--';
         document.getElementById('overview-mdd').textContent = selectedAlgo.mdd || '--';
@@ -38,9 +48,87 @@ document.addEventListener('DOMContentLoaded', async function () {
         const data = await dataProvider.getHistory(symbol, 'D');
         if (data && data.length) {
             mainSeries.setData(data);
+
+            const config = {
+                buyConditions: selectedAlgo?.buyConditions || [],
+                sellConditions: selectedAlgo?.sellConditions || []
+            };
+
+            // Tính và overlay các chỉ báo SMA từ cấu hình
+            const smaPeriods = new Set();
+            [...config.buyConditions, ...config.sellConditions].forEach(c => {
+                if (c.type === 'sma-crossover') {
+                    smaPeriods.add(c.params.shortPeriod);
+                    smaPeriods.add(c.params.longPeriod);
+                }
+            });
+
+            const smaColors = ['#2962FF', '#FF6D00', '#D81B60', '#43A047', '#6D4C41'];
+            Array.from(smaPeriods).forEach((period, idx) => {
+                const smaData = [];
+                for (let i = 0; i < data.length; i++) {
+                    const value = strategyEngine.calculateSMA(data, period, i);
+                    smaData.push({
+                        time: data[i].time,
+                        value: value !== null ? value : undefined
+                    });
+                }
+                const line = chart.addLineSeries({
+                    color: smaColors[idx % smaColors.length],
+                    lineWidth: 2,
+                    crosshairMarkerVisible: false,
+                    lastValueVisible: false,
+                    priceLineVisible: false
+                });
+                line.setData(smaData);
+            });
+
+            // Nếu có điều kiện RSI thì overlay RSI
+            const hasRSI = [...config.buyConditions, ...config.sellConditions].some(c => c.type === 'rsi');
+            if (hasRSI) {
+                const rsiSeries = chart.addLineSeries({
+                    color: '#8884d8',
+                    lineWidth: 1,
+                    priceScaleId: 'rsi',
+                    crosshairMarkerVisible: false,
+                    lastValueVisible: false,
+                    priceLineVisible: false
+                });
+                chart.priceScale('rsi').applyOptions({ scaleMargins: { top: 0.8, bottom: 0 } });
+                const rsiData = data.map((d, idx) => {
+                    const value = strategyEngine.calculateRSI(data, idx);
+                    return { time: d.time, value: value !== null ? value : undefined };
+                });
+                rsiSeries.setData(rsiData);
+            }
+
+            // Xác định các điểm mua/bán
+            const markers = [];
+            const minPeriod = strategyEngine.getMinRequiredPeriod(config);
+            for (let i = minPeriod; i < data.length; i++) {
+                const current = data[i];
+                if (strategyEngine.evaluateConditions(config.buyConditions, data, i, 'buy')) {
+                    markers.push({
+                        time: current.time,
+                        position: 'belowBar',
+                        color: '#2196F3',
+                        shape: 'arrowUp',
+                        text: `Buy @ ${current.close.toFixed(2)}`
+                    });
+                }
+                if (strategyEngine.evaluateConditions(config.sellConditions, data, i, 'sell')) {
+                    markers.push({
+                        time: current.time,
+                        position: 'aboveBar',
+                        color: '#e91e63',
+                        shape: 'arrowDown',
+                        text: `Sell @ ${current.close.toFixed(2)}`
+                    });
+                }
+            }
+            strategyEngine.displayMarkers(markers);
         }
     } catch (error) {
         console.error('Không thể tải dữ liệu biểu đồ:', error);
     }
-
 });


### PR DESCRIPTION
## Summary
- load selected strategy from URL/localStorage and display overview
- fetch symbol history and overlay SMA/RSI indicators
- compute buy/sell markers based on strategy conditions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad298e205c83219676746ce2af5ebb