### PR TITLE
feat: backtest metrics and navigation

### DIFF
--- a/algo-detail.html
+++ b/algo-detail.html
@@ -11,11 +11,14 @@
     <div class="algo-container">
         <main id="chart-area"></main>
         <aside class="algo-sidebar">
+            <button id="back-to-list" class="back-button">&larr; Danh sách</button>
             <h2>Tổng quan</h2>
             <ul class="overview-list">
                 <li>Winrate: <span id="overview-winrate">--%</span></li>
                 <li>MDD: <span id="overview-mdd">--%</span></li>
                 <li>Lợi nhuận: <span id="overview-profit">--</span></li>
+                <li>Số lệnh: <span id="overview-trades">--</span></li>
+                <li>Profit Factor: <span id="overview-profit-factor">--</span></li>
             </ul>
         </aside>
     </div>

--- a/css/algo-detail.css
+++ b/css/algo-detail.css
@@ -15,6 +15,10 @@
     font-size: 0.9em;
 }
 
+.back-button {
+    margin-bottom: 10px;
+}
+
 .overview-list {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
## Summary
- Call `/api/backtest` with price data and algo conditions to obtain metrics and trade markers
- Display winrate, drawdown, profit, trade count, and profit factor in the detail sidebar
- Add a back button for returning to the algo list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad3305071883218813df87df0b1f26