### PR TITLE
feat: backtest metrics and navigation

### DIFF
--- a/algo-detail.html
+++ b/algo-detail.html
@@ -8,21 +8,82 @@
     <link rel="stylesheet" href="css/algo-detail.css">
 </head>
 <body>
-    <div class="algo-container">
-        <main id="chart-area"></main>
-        <aside class="algo-sidebar">
-            <h2>Tổng quan</h2>
-            <ul class="overview-list">
+<div class="container">
+    <header class="header">
+        <div class="left-header">
+            <div class="symbol-info">
+                <strong id="symbol-display">--</strong>
+                <span id="symbol-description"></span>
+            </div>
+            <div class="ohlc-info"></div>
+        </div>
+        <div class="right-header">
+            <button class="tool-button" id="back-to-list">Danh sách</button>
+        </div>
+    </header>
+    <aside class="left-toolbar">
+        <button class="toolbar-button" id="draw-trend-line-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+                <path fill="currentColor" d="M3.707 20.293a1 1 0 0 0 1.414 0l16-16a1 1 0 0 0-1.414-1.414l-16 16a1 1 0 0 0 0 1.414Z"/>
+            </svg>
+        </button>
+    </aside>
+    <main class="main-chart">
+        <div id="main-chart-container"></div>
+    </main>
+    <aside class="right-sidebar">
+        <div class="market-data-panel">
+            <div class="price-section">
+                <div id="sidebar-price" class="current-price">---</div>
+                <div class="price-change">
+                    <span id="sidebar-change">---</span>
+                    (<span id="sidebar-percent-change">---</span>)
+                </div>
+            </div>
+            <div class="stats-grid">
+                <div class="stat-item">
+                    <span class="stat-label">Cao nhất</span>
+                    <span id="sidebar-high" class="stat-value">---</span>
+                </div>
+                <div class="stat-item">
+                    <span class="stat-label">Thấp nhất</span>
+                    <span id="sidebar-low" class="stat-value">---</span>
+                </div>
+                <div class="stat-item">
+                    <span class="stat-label">Mở cửa</span>
+                    <span id="sidebar-open" class="stat-value">---</span>
+                </div>
+                <div class="stat-item">
+                    <span class="stat-label">Tham chiếu</span>
+                    <span id="sidebar-ref" class="stat-value">---</span>
+                </div>
+                <div class="stat-item">
+                    <span class="stat-label">KLGD</span>
+                    <span id="sidebar-volume" class="stat-value">---</span>
+                </div>
+                <div class="stat-item">
+                    <span class="stat-label">GTGD</span>
+                    <span id="sidebar-value" class="stat-value">---</span>
+                </div>
+            </div>
+        </div>
+        <div class="metrics-panel">
+            <h3>Tổng quan</h3>
+            <ul>
                 <li>Winrate: <span id="overview-winrate">--%</span></li>
                 <li>MDD: <span id="overview-mdd">--%</span></li>
                 <li>Lợi nhuận: <span id="overview-profit">--</span></li>
+                <li>Số lệnh: <span id="overview-trades">--</span></li>
+                <li>Profit Factor: <span id="overview-profit-factor">--</span></li>
             </ul>
-        </aside>
-    </div>
+        </div>
+    </aside>
+</div>
 
-    <script src="https://unpkg.com/lightweight-charts@4.1.0/dist/lightweight-charts.standalone.production.js"></script>
-    <script src="src/core/StrategyEngine.js"></script>
-    <script src="src/core/DataProvider.js"></script>
-    <script src="src/pages/algo-detail.js"></script>
+<script src="https://unpkg.com/lightweight-charts@4.1.0/dist/lightweight-charts.standalone.production.js"></script>
+<script src="src/tools/TrendLinePrimitive.js"></script>
+<script src="src/core/StrategyEngine.js"></script>
+<script src="src/core/DataProvider.js"></script>
+<script src="src/pages/algo-detail.js"></script>
 </body>
 </html>

--- a/css/algo-detail.css
+++ b/css/algo-detail.css
@@ -1,26 +1,18 @@
-.algo-container {
-    display: flex;
-    height: 100vh;
-}
-
-#chart-area {
-    flex: 1;
-    background-color: white;
-}
-
-.algo-sidebar {
-    width: 280px;
-    background-color: white;
-    padding: 15px;
+.metrics-panel {
+    margin-top: 20px;
     font-size: 0.9em;
 }
 
-.overview-list {
+.metrics-panel ul {
     list-style: none;
     padding: 0;
     margin: 0;
 }
 
-.overview-list li {
+.metrics-panel li {
     margin-bottom: 8px;
+}
+
+#back-to-list {
+    margin-right: 10px;
 }

--- a/src/pages/algo-detail.js
+++ b/src/pages/algo-detail.js
@@ -1,5 +1,4 @@
 document.addEventListener('DOMContentLoaded', async function () {
-    // Lấy tên algo từ URL hoặc localStorage
     const params = new URLSearchParams(window.location.search);
     const algoName = params.get('name');
 
@@ -16,17 +15,21 @@ document.addEventListener('DOMContentLoaded', async function () {
         console.error('Không thể đọc dữ liệu algo đã chọn:', err);
     }
 
-    // Hiển thị tổng quan
-    if (selectedAlgo) {
-        document.getElementById('overview-winrate').textContent = selectedAlgo.winrate || '--';
-        document.getElementById('overview-mdd').textContent = selectedAlgo.mdd || '--';
-        document.getElementById('overview-profit').textContent = selectedAlgo.profit || '--';
+    const backBtn = document.getElementById('back-to-list');
+    if (backBtn) {
+        backBtn.addEventListener('click', () => {
+            window.location.href = 'algo-list.html';
+        });
     }
 
+    const dataProvider = new DataProvider();
     const symbol = (selectedAlgo && selectedAlgo.code) ? selectedAlgo.code : 'VNINDEX';
+    document.getElementById('symbol-display').textContent = symbol;
+    document.getElementById('symbol-description').textContent = await dataProvider.getCompanyInfo(symbol);
 
-    const chartArea = document.getElementById('chart-area');
-    const chart = LightweightCharts.createChart(chartArea, {
+    const ohlcContainer = document.querySelector('.ohlc-info');
+    const chartContainer = document.getElementById('main-chart-container');
+    const chart = LightweightCharts.createChart(chartContainer, {
         autoSize: true,
         layout: { background: { color: '#ffffff' }, textColor: '#333' },
         grid: { vertLines: { color: '#f0f3f5' }, horzLines: { color: '#f0f3f5' } },
@@ -41,20 +44,98 @@ document.addEventListener('DOMContentLoaded', async function () {
         wickDownColor: '#ef5350'
     });
 
-    const dataProvider = new DataProvider();
+    function onCrosshairMoved(param) {
+        if (!param.time || !param.seriesData.has(mainSeries)) {
+            ohlcContainer.textContent = '';
+            return;
+        }
+        const d = param.seriesData.get(mainSeries);
+        ohlcContainer.innerHTML = `<span class="label">O:</span> ${d.open.toFixed(2)} <span class="label">H:</span> ${d.high.toFixed(2)} <span class="label">L:</span> ${d.low.toFixed(2)} <span class="label">C:</span> ${d.close.toFixed(2)}`;
+    }
+    chart.subscribeCrosshairMove(onCrosshairMoved);
+
     const strategyEngine = new StrategyEngine(chart, mainSeries);
+
+    function formatLargeNumber(num) {
+        if (!num || isNaN(num)) return '---';
+        if (num >= 1e9) {
+            return (num / 1e9).toFixed(2) + ' tỷ';
+        }
+        if (num >= 1e6) {
+            return (num / 1e6).toFixed(1) + ' tr';
+        }
+        if (num >= 1e3) {
+            return (num / 1e3).toFixed(0) + ' k';
+        }
+        return num.toLocaleString();
+    }
+
+    function updateSidebar(latestData, previousData) {
+        const priceEl = document.getElementById('sidebar-price');
+        const changeEl = document.getElementById('sidebar-change');
+        const percentChangeEl = document.getElementById('sidebar-percent-change');
+        const highEl = document.getElementById('sidebar-high');
+        const lowEl = document.getElementById('sidebar-low');
+        const openEl = document.getElementById('sidebar-open');
+        const refEl = document.getElementById('sidebar-ref');
+        const volumeEl = document.getElementById('sidebar-volume');
+        const valueEl = document.getElementById('sidebar-value');
+
+        if (!latestData) {
+            [priceEl, changeEl, percentChangeEl, highEl, lowEl, openEl, refEl, volumeEl, valueEl].forEach(el => {
+                if (el) el.textContent = '---';
+            });
+            return;
+        }
+
+        const close = latestData.close;
+        const refPrice = previousData ? previousData.close : latestData.open;
+        const change = close - refPrice;
+        const percentChange = refPrice === 0 ? 0 : (change / refPrice) * 100;
+        const tradingValue = latestData.close * latestData.volume;
+
+        priceEl.textContent = close.toFixed(2);
+        changeEl.textContent = `${change >= 0 ? '+' : ''}${change.toFixed(2)}`;
+        percentChangeEl.textContent = `${percentChange.toFixed(2)}%`;
+        highEl.textContent = latestData.high.toFixed(2);
+        lowEl.textContent = latestData.low.toFixed(2);
+        openEl.textContent = latestData.open.toFixed(2);
+        refEl.textContent = refPrice.toFixed(2);
+        volumeEl.textContent = formatLargeNumber(latestData.volume);
+        valueEl.textContent = formatLargeNumber(tradingValue);
+
+        const elementsToColor = [priceEl, changeEl, percentChangeEl, highEl, lowEl, openEl];
+        elementsToColor.forEach(el => el.classList.remove('color-red', 'color-green', 'color-yellow'));
+        let colorClass = 'color-yellow';
+        if (change > 0) colorClass = 'color-green';
+        else if (change < 0) colorClass = 'color-red';
+        [priceEl, changeEl, percentChangeEl].forEach(el => el.classList.add(colorClass));
+
+        const priceFields = [
+            { el: highEl, value: latestData.high },
+            { el: lowEl, value: latestData.low },
+            { el: openEl, value: latestData.open },
+        ];
+        priceFields.forEach(field => {
+            if (field.value > refPrice) field.el.classList.add('color-green');
+            else if (field.value < refPrice) field.el.classList.add('color-red');
+            else field.el.classList.add('color-yellow');
+        });
+    }
 
     try {
         const data = await dataProvider.getHistory(symbol, 'D');
         if (data && data.length) {
             mainSeries.setData(data);
+            const last = data[data.length - 1];
+            const prev = data[data.length - 2];
+            updateSidebar(last, prev);
 
             const config = {
                 buyConditions: selectedAlgo?.buyConditions || [],
                 sellConditions: selectedAlgo?.sellConditions || []
             };
 
-            // Tính và overlay các chỉ báo SMA từ cấu hình
             const smaPeriods = new Set();
             [...config.buyConditions, ...config.sellConditions].forEach(c => {
                 if (c.type === 'sma-crossover') {
@@ -83,7 +164,6 @@ document.addEventListener('DOMContentLoaded', async function () {
                 line.setData(smaData);
             });
 
-            // Nếu có điều kiện RSI thì overlay RSI
             const hasRSI = [...config.buyConditions, ...config.sellConditions].some(c => c.type === 'rsi');
             if (hasRSI) {
                 const rsiSeries = chart.addLineSeries({
@@ -102,33 +182,78 @@ document.addEventListener('DOMContentLoaded', async function () {
                 rsiSeries.setData(rsiData);
             }
 
-            // Xác định các điểm mua/bán
-            const markers = [];
-            const minPeriod = strategyEngine.getMinRequiredPeriod(config);
-            for (let i = minPeriod; i < data.length; i++) {
-                const current = data[i];
-                if (strategyEngine.evaluateConditions(config.buyConditions, data, i, 'buy')) {
-                    markers.push({
-                        time: current.time,
-                        position: 'belowBar',
-                        color: '#2196F3',
-                        shape: 'arrowUp',
-                        text: `Buy @ ${current.close.toFixed(2)}`
+            try {
+                const result = await dataProvider.runBacktest({
+                    prices: data,
+                    buyConditions: config.buyConditions,
+                    sellConditions: config.sellConditions
+                });
+                const metrics = result?.metrics || {};
+                document.getElementById('overview-winrate').textContent =
+                    metrics.winrate != null ? (metrics.winrate * 100).toFixed(2) + '%' : '--%';
+                document.getElementById('overview-mdd').textContent =
+                    metrics.max_drawdown != null ? (metrics.max_drawdown * 100).toFixed(2) + '%' : '--%';
+                document.getElementById('overview-profit').textContent =
+                    metrics.total_return != null ? (metrics.total_return * 100).toFixed(2) + '%' : '--';
+                document.getElementById('overview-trades').textContent =
+                    metrics.num_trades != null ? metrics.num_trades : '--';
+                document.getElementById('overview-profit-factor').textContent =
+                    metrics.profit_factor != null ? metrics.profit_factor.toFixed(2) : '--';
+
+                const markers = [];
+                if (Array.isArray(result?.trades)) {
+                    result.trades.forEach(trade => {
+                        markers.push({
+                            time: trade.buy_time,
+                            position: 'belowBar',
+                            color: '#2196F3',
+                            shape: 'arrowUp',
+                            text: `Buy @ ${trade.buy_price.toFixed(2)}`
+                        });
+                        markers.push({
+                            time: trade.sell_time,
+                            position: 'aboveBar',
+                            color: '#e91e63',
+                            shape: 'arrowDown',
+                            text: `Sell @ ${trade.sell_price.toFixed(2)}`
+                        });
                     });
                 }
-                if (strategyEngine.evaluateConditions(config.sellConditions, data, i, 'sell')) {
-                    markers.push({
-                        time: current.time,
-                        position: 'aboveBar',
-                        color: '#e91e63',
-                        shape: 'arrowDown',
-                        text: `Sell @ ${current.close.toFixed(2)}`
-                    });
-                }
+                strategyEngine.displayMarkers(markers);
+            } catch (err) {
+                console.error('Không thể backtest:', err);
             }
-            strategyEngine.displayMarkers(markers);
         }
     } catch (error) {
         console.error('Không thể tải dữ liệu biểu đồ:', error);
     }
+
+    // Drawing tool
+    const drawBtn = document.getElementById('draw-trend-line-btn');
+    let drawing = false;
+    let firstPoint = null;
+    drawBtn.addEventListener('click', () => {
+        drawing = !drawing;
+        drawBtn.classList.toggle('active', drawing);
+        if (!drawing) firstPoint = null;
+    });
+    chartContainer.addEventListener('click', (event) => {
+        if (!drawing) return;
+        const rect = chartContainer.getBoundingClientRect();
+        const x = event.clientX - rect.left;
+        const y = event.clientY - rect.top;
+        const time = chart.timeScale().coordinateToTime(x);
+        const price = mainSeries.coordinateToPrice(y);
+        if (!time || price === null) return;
+        if (!firstPoint) {
+            firstPoint = { time, price };
+        } else {
+            const line = new TrendLine(chart, mainSeries, firstPoint, { time, price });
+            mainSeries.attachPrimitive(line);
+            line.updateAllViews();
+            drawing = false;
+            firstPoint = null;
+            drawBtn.classList.remove('active');
+        }
+    });
 });


### PR DESCRIPTION
## Summary
- Rework algo detail layout with header, market data, metrics panel, and drawing tool
- Fetch company info and backtest results to show accurate winrate, drawdown, profit, trade count, and markers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad3305071883218813df87df0b1f26