### PR TITLE
feat: improve algo detail layout and navigation

### DIFF
--- a/algo-detail.html
+++ b/algo-detail.html
@@ -18,7 +18,7 @@
             <div class="ohlc-info"></div>
         </div>
         <div class="right-header">
-            <button class="tool-button" id="back-to-list">Danh sách</button>
+            <a href="algo-list.html" class="tool-button" id="back-to-list">Quay lại</a>
         </div>
     </header>
     <aside class="left-toolbar">

--- a/css/algo-detail.css
+++ b/css/algo-detail.css
@@ -1,10 +1,66 @@
+.main-chart {
+    position: relative;
+}
+
+#main-chart-container {
+    width: 100%;
+    height: 100%;
+}
+
+.right-sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    padding: 10px;
+    box-sizing: border-box;
+    border-left: 1px solid #eee;
+    overflow-y: auto;
+}
+
+.market-data-panel {
+    padding-bottom: 10px;
+    border-bottom: 1px solid #eee;
+}
+
+.price-section {
+    margin-bottom: 10px;
+}
+
+.current-price {
+    font-size: 1.4em;
+    font-weight: bold;
+}
+
+.price-change {
+    font-size: 0.9em;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px 10px;
+    font-size: 0.85em;
+}
+
+.stat-item {
+    display: flex;
+    flex-direction: column;
+}
+
+.stat-label {
+    color: #666;
+}
+
+.stat-value {
+    font-weight: bold;
+}
+
 .metrics-panel {
     margin-top: 20px;
     font-size: 0.9em;
 }
 
 .metrics-panel ul {
-
     list-style: none;
     padding: 0;
     margin: 0;
@@ -16,4 +72,33 @@
 
 #back-to-list {
     margin-right: 10px;
+}
+
+@media (max-width: 768px) {
+    .container {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto 1fr auto;
+    }
+
+    .left-toolbar {
+        display: none;
+    }
+
+    .right-sidebar {
+        grid-column: 1;
+        grid-row: 3;
+        flex-direction: row;
+        flex-wrap: wrap;
+        border-left: none;
+        border-top: 1px solid #eee;
+    }
+
+    .market-data-panel,
+    .metrics-panel {
+        flex: 1 1 250px;
+    }
+
+    #main-chart-container {
+        height: 60vh;
+    }
 }


### PR DESCRIPTION
## Summary
- style algo detail page with responsive sidebar and chart
- add explicit back link to algo list

## Testing
- `npx browserslist "last 2 Chrome versions, last 2 Firefox versions, last 2 Safari versions"`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad40a0aa108321aea1d29cfc0bf819