### PR TITLE
refactor: share strategy builder component

### DIFF
--- a/algo-list.html
+++ b/algo-list.html
@@ -47,72 +47,6 @@
             <tbody id="algo-table-body"></tbody>
         </table>
     </div>
-
-    <!-- Strategy Builder Panel -->
-    <div id="strategy-builder-panel" class="strategy-builder-panel" style="display: none;">
-        <div class="strategy-builder-header">
-            <h3>Strategy Builder</h3>
-            <button id="close-strategy-builder" class="close-btn">&times;</button>
-        </div>
-        <div class="strategy-builder-content">
-            <div class="strategy-name-section">
-                <label for="strategy-name">Tên chiến lược:</label>
-                <input type="text" id="strategy-name" placeholder="Nhập tên chiến lược..." value="SMA Crossover Strategy">
-            </div>
-
-            <div class="strategy-code-section">
-                <label for="strategy-code">Mã chứng khoán:</label>
-                <input type="text" id="strategy-code" placeholder="VD: FPT">
-            </div>
-
-            <div class="conditions-section">
-                <h4>Điều kiện mua (BUY):</h4>
-                <div id="buy-conditions" class="conditions-container">
-                    <div class="condition-item">
-                        <select class="condition-type">
-                            <option value="sma-crossover">SMA Crossover</option>
-                            <option value="rsi">RSI</option>
-                            <option value="price">Giá</option>
-                        </select>
-                        <div class="condition-params">
-                            <input type="number" class="param-input" placeholder="9" min="1" max="100">
-                            <span>cắt lên</span>
-                            <input type="number" class="param-input" placeholder="20" min="1" max="100">
-                        </div>
-                        <button class="remove-condition-btn">&times;</button>
-                    </div>
-                </div>
-                <button id="add-buy-condition" class="add-condition-btn">+ Thêm điều kiện</button>
-            </div>
-
-            <div class="conditions-section">
-                <h4>Điều kiện bán (SELL):</h4>
-                <div id="sell-conditions" class="conditions-container">
-                    <div class="condition-item">
-                        <select class="condition-type">
-                            <option value="sma-crossover">SMA Crossover</option>
-                            <option value="rsi">RSI</option>
-                            <option value="price">Giá</option>
-                        </select>
-                        <div class="condition-params">
-                            <input type="number" class="param-input" placeholder="9" min="1" max="100">
-                            <span>cắt xuống</span>
-                            <input type="number" class="param-input" placeholder="20" min="1" max="100">
-                        </div>
-                        <button class="remove-condition-btn">&times;</button>
-                    </div>
-                </div>
-                <button id="add-sell-condition" class="add-condition-btn">+ Thêm điều kiện</button>
-            </div>
-
-            <div class="strategy-actions">
-                <button id="test-strategy-btn" class="action-btn primary">Test Strategy</button>
-                <button id="save-strategy-btn" class="action-btn">Lưu Strategy</button>
-                <button id="load-strategy-btn" class="action-btn">Tải Strategy</button>
-            </div>
-        </div>
-    </div>
-
     <script src="src/core/StrategyEngine.js"></script>
     <script src="src/core/DataProvider.js"></script>
     <script>
@@ -120,7 +54,25 @@
     var currentCandlestickData = [];
     var strategyEngine = new StrategyEngine(null, null);
     </script>
-    <script src="src/pages/strategy-builder.js"></script>
-    <script src="src/pages/algo-list.js"></script>
+    <script>
+  fetch('strategy-builder-component.html')
+    .then(res => res.text())
+    .then(html => {
+      document.body.insertAdjacentHTML('beforeend', html);
+      const sbScript = document.createElement('script');
+      sbScript.src = 'src/pages/strategy-builder.js';
+      sbScript.onload = () => {
+        const algoScript = document.createElement('script');
+        algoScript.src = 'src/pages/algo-list.js';
+        algoScript.onload = () => {
+          document.dispatchEvent(new Event('DOMContentLoaded'));
+        };
+        document.body.appendChild(algoScript);
+      };
+      document.body.appendChild(sbScript);
+    })
+    .catch(err => console.error('Không thể tải Strategy Builder:', err));
+</script>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -97,72 +97,6 @@
             </div>
         </aside>
         </div>
-
-        <!-- Strategy Builder Panel -->
-        <div id="strategy-builder-panel" class="strategy-builder-panel" style="display: none;">
-            <div class="strategy-builder-header">
-                <h3>Strategy Builder</h3>
-                <button id="close-strategy-builder" class="close-btn">&times;</button>
-            </div>
-            <div class="strategy-builder-content">
-                <div class="strategy-name-section">
-                    <label for="strategy-name">Tên chiến lược:</label>
-                    <input type="text" id="strategy-name" placeholder="Nhập tên chiến lược..." value="SMA Crossover Strategy">
-                </div>
-
-                <div class="strategy-code-section">
-                    <label for="strategy-code">Mã chứng khoán:</label>
-                    <input type="text" id="strategy-code" placeholder="VD: FPT">
-                </div>
-                
-                <div class="conditions-section">
-                    <h4>Điều kiện mua (BUY):</h4>
-                    <div id="buy-conditions" class="conditions-container">
-                        <div class="condition-item">
-                            <select class="condition-type">
-                                <option value="sma-crossover">SMA Crossover</option>
-                                <option value="rsi">RSI</option>
-                                <option value="price">Giá</option>
-                            </select>
-                            <div class="condition-params">
-                                <input type="number" class="param-input" placeholder="9" min="1" max="100">
-                                <span>cắt lên</span>
-                                <input type="number" class="param-input" placeholder="20" min="1" max="100">
-                            </div>
-                            <button class="remove-condition-btn">&times;</button>
-                        </div>
-                    </div>
-                    <button id="add-buy-condition" class="add-condition-btn">+ Thêm điều kiện</button>
-                </div>
-
-                <div class="conditions-section">
-                    <h4>Điều kiện bán (SELL):</h4>
-                    <div id="sell-conditions" class="conditions-container">
-                        <div class="condition-item">
-                            <select class="condition-type">
-                                <option value="sma-crossover">SMA Crossover</option>
-                                <option value="rsi">RSI</option>
-                                <option value="price">Giá</option>
-                            </select>
-                            <div class="condition-params">
-                                <input type="number" class="param-input" placeholder="9" min="1" max="100">
-                                <span>cắt xuống</span>
-                                <input type="number" class="param-input" placeholder="20" min="1" max="100">
-                            </div>
-                            <button class="remove-condition-btn">&times;</button>
-                        </div>
-                    </div>
-                    <button id="add-sell-condition" class="add-condition-btn">+ Thêm điều kiện</button>
-                </div>
-
-                <div class="strategy-actions">
-                    <button id="test-strategy-btn" class="action-btn primary">Test Strategy</button>
-                    <button id="save-strategy-btn" class="action-btn">Lưu Strategy</button>
-                    <button id="load-strategy-btn" class="action-btn">Tải Strategy</button>
-                </div>
-            </div>
-        </div>
-
     <script src="https://unpkg.com/lightweight-charts@4.1.0/dist/lightweight-charts.standalone.production.js"></script>
     <script src="src/core/ChartSyncManager.js"></script>
     <script src="src/indicators/MACDIndicator.js"></script>
@@ -175,7 +109,17 @@
     
     <script src="src/core/DataProvider.js"></script>
     <script src="src/pages/script.js"></script>
-    <script src="src/pages/strategy-builder.js"></script>
+    <script>
+  fetch('strategy-builder-component.html')
+    .then(res => res.text())
+    .then(html => {
+      document.body.insertAdjacentHTML('beforeend', html);
+      const script = document.createElement('script');
+      script.src = 'src/pages/strategy-builder.js';
+      document.body.appendChild(script);
+    })
+    .catch(err => console.error('Không thể tải Strategy Builder:', err));
+</script>
 
 </body>
 </html>

--- a/src/pages/strategy-builder.js
+++ b/src/pages/strategy-builder.js
@@ -1,3 +1,12 @@
+// Utility used by StrategyBuilderUI. If the global helper is not present
+// (e.g. on pages that don't load script.js), define a minimal version here.
+if (typeof areTimesEqual !== 'function') {
+    function areTimesEqual(time1, time2) {
+        if (!time1 || !time2) return false;
+        return JSON.stringify(time1) === JSON.stringify(time2);
+    }
+}
+
 class StrategyBuilderUI {
     constructor() {
         this.panel = document.getElementById('strategy-builder-panel');

--- a/strategy-builder-component.html
+++ b/strategy-builder-component.html
@@ -1,0 +1,64 @@
+<!-- Strategy Builder Panel -->
+<div id="strategy-builder-panel" class="strategy-builder-panel" style="display: none;">
+    <div class="strategy-builder-header">
+        <h3>Strategy Builder</h3>
+        <button id="close-strategy-builder" class="close-btn">&times;</button>
+    </div>
+    <div class="strategy-builder-content">
+        <div class="strategy-name-section">
+            <label for="strategy-name">Tên chiến lược:</label>
+            <input type="text" id="strategy-name" placeholder="Nhập tên chiến lược..." value="SMA Crossover Strategy">
+        </div>
+
+        <div class="strategy-code-section">
+            <label for="strategy-code">Mã chứng khoán:</label>
+            <input type="text" id="strategy-code" placeholder="VD: FPT">
+        </div>
+
+        <div class="conditions-section">
+            <h4>Điều kiện mua (BUY):</h4>
+            <div id="buy-conditions" class="conditions-container">
+                <div class="condition-item">
+                    <select class="condition-type">
+                        <option value="sma-crossover">SMA Crossover</option>
+                        <option value="rsi">RSI</option>
+                        <option value="price">Giá</option>
+                    </select>
+                    <div class="condition-params">
+                        <input type="number" class="param-input" placeholder="9" min="1" max="100">
+                        <span>cắt lên</span>
+                        <input type="number" class="param-input" placeholder="20" min="1" max="100">
+                    </div>
+                    <button class="remove-condition-btn">&times;</button>
+                </div>
+            </div>
+            <button id="add-buy-condition" class="add-condition-btn">+ Thêm điều kiện</button>
+        </div>
+
+        <div class="conditions-section">
+            <h4>Điều kiện bán (SELL):</h4>
+            <div id="sell-conditions" class="conditions-container">
+                <div class="condition-item">
+                    <select class="condition-type">
+                        <option value="sma-crossover">SMA Crossover</option>
+                        <option value="rsi">RSI</option>
+                        <option value="price">Giá</option>
+                    </select>
+                    <div class="condition-params">
+                        <input type="number" class="param-input" placeholder="9" min="1" max="100">
+                        <span>cắt xuống</span>
+                        <input type="number" class="param-input" placeholder="20" min="1" max="100">
+                    </div>
+                    <button class="remove-condition-btn">&times;</button>
+                </div>
+            </div>
+            <button id="add-sell-condition" class="add-condition-btn">+ Thêm điều kiện</button>
+        </div>
+
+        <div class="strategy-actions">
+            <button id="test-strategy-btn" class="action-btn primary">Test Strategy</button>
+            <button id="save-strategy-btn" class="action-btn">Lưu Strategy</button>
+            <button id="load-strategy-btn" class="action-btn">Tải Strategy</button>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- factor Strategy Builder panel into reusable `strategy-builder-component.html`
- dynamically load Strategy Builder into `index.html`
- dynamically load Strategy Builder and related scripts into `algo-list.html`
- ensure `areTimesEqual` helper exists when `script.js` isn't loaded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad50dfa0c8832183ffffe055c22d05