### PR TITLE
Gracefully handle missing strategy builder

### DIFF
--- a/algo-list.html
+++ b/algo-list.html
@@ -55,6 +55,15 @@
     var strategyEngine = new StrategyEngine(null, null);
     </script>
     <script>
+  function loadAlgoList() {
+    const algoScript = document.createElement('script');
+    algoScript.src = 'src/pages/algo-list.js';
+    algoScript.onload = () => {
+      document.dispatchEvent(new Event('DOMContentLoaded'));
+    };
+    document.body.appendChild(algoScript);
+  }
+
   fetch('strategy-builder-component.html')
     .then(res => res.text())
     .then(html => {
@@ -62,16 +71,19 @@
       const sbScript = document.createElement('script');
       sbScript.src = 'src/pages/strategy-builder.js';
       sbScript.onload = () => {
-        const algoScript = document.createElement('script');
-        algoScript.src = 'src/pages/algo-list.js';
-        algoScript.onload = () => {
-          document.dispatchEvent(new Event('DOMContentLoaded'));
-        };
-        document.body.appendChild(algoScript);
+        loadAlgoList();
       };
       document.body.appendChild(sbScript);
     })
-    .catch(err => console.error('Không thể tải Strategy Builder:', err));
+    .catch(err => {
+      console.error('Không thể tải Strategy Builder:', err);
+      window.strategyBuilderUI = {
+        loadStrategyConfig: () => {},
+        open: () => alert('Strategy Builder không thể tải'),
+        testStrategy: () => {}
+      };
+      loadAlgoList();
+    });
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- Ensure algo list initializes even when Strategy Builder component fails to load
- Provide fallback stub for Strategy Builder and alert when unavailable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad7337cea08321b7da99bedf471ee0