### PR TITLE
Embed Strategy Builder markup to prevent load failure

### DIFF
--- a/algo-list.html
+++ b/algo-list.html
@@ -54,37 +54,74 @@
     var currentCandlestickData = [];
     var strategyEngine = new StrategyEngine(null, null);
     </script>
-    <script>
-  function loadAlgoList() {
-    const algoScript = document.createElement('script');
-    algoScript.src = 'src/pages/algo-list.js';
-    algoScript.onload = () => {
-      document.dispatchEvent(new Event('DOMContentLoaded'));
-    };
-    document.body.appendChild(algoScript);
-  }
 
-  fetch('strategy-builder-component.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
-      const sbScript = document.createElement('script');
-      sbScript.src = 'src/pages/strategy-builder.js';
-      sbScript.onload = () => {
-        loadAlgoList();
-      };
-      document.body.appendChild(sbScript);
-    })
-    .catch(err => {
-      console.error('Không thể tải Strategy Builder:', err);
-      window.strategyBuilderUI = {
-        loadStrategyConfig: () => {},
-        open: () => alert('Strategy Builder không thể tải'),
-        testStrategy: () => {}
-      };
-      loadAlgoList();
-    });
-</script>
+    <!-- Strategy Builder Panel -->
+    <div id="strategy-builder-panel" class="strategy-builder-panel" style="display: none;">
+        <div class="strategy-builder-header">
+            <h3>Strategy Builder</h3>
+            <button id="close-strategy-builder" class="close-btn">&times;</button>
+        </div>
+        <div class="strategy-builder-content">
+            <div class="strategy-name-section">
+                <label for="strategy-name">Tên chiến lược:</label>
+                <input type="text" id="strategy-name" placeholder="Nhập tên chiến lược..." value="SMA Crossover Strategy">
+            </div>
+
+            <div class="strategy-code-section">
+                <label for="strategy-code">Mã chứng khoán:</label>
+                <input type="text" id="strategy-code" placeholder="VD: FPT">
+            </div>
+
+            <div class="conditions-section">
+                <h4>Điều kiện mua (BUY):</h4>
+                <div id="buy-conditions" class="conditions-container">
+                    <div class="condition-item">
+                        <select class="condition-type">
+                            <option value="sma-crossover">SMA Crossover</option>
+                            <option value="rsi">RSI</option>
+                            <option value="price">Giá</option>
+                        </select>
+                        <div class="condition-params">
+                            <input type="number" class="param-input" placeholder="9" min="1" max="100">
+                            <span>cắt lên</span>
+                            <input type="number" class="param-input" placeholder="20" min="1" max="100">
+                        </div>
+                        <button class="remove-condition-btn">&times;</button>
+                    </div>
+                </div>
+                <button id="add-buy-condition" class="add-condition-btn">+ Thêm điều kiện</button>
+            </div>
+
+            <div class="conditions-section">
+                <h4>Điều kiện bán (SELL):</h4>
+                <div id="sell-conditions" class="conditions-container">
+                    <div class="condition-item">
+                        <select class="condition-type">
+                            <option value="sma-crossover">SMA Crossover</option>
+                            <option value="rsi">RSI</option>
+                            <option value="price">Giá</option>
+                        </select>
+                        <div class="condition-params">
+                            <input type="number" class="param-input" placeholder="9" min="1" max="100">
+                            <span>cắt xuống</span>
+                            <input type="number" class="param-input" placeholder="20" min="1" max="100">
+                        </div>
+                        <button class="remove-condition-btn">&times;</button>
+                    </div>
+                </div>
+                <button id="add-sell-condition" class="add-condition-btn">+ Thêm điều kiện</button>
+            </div>
+
+            <div class="strategy-actions">
+                <button id="test-strategy-btn" class="action-btn primary">Test Strategy</button>
+                <button id="save-strategy-btn" class="action-btn">Lưu Strategy</button>
+                <button id="load-strategy-btn" class="action-btn">Tải Strategy</button>
+            </div>
+        </div>
+    </div>
+
+    <script src="src/pages/strategy-builder.js" defer></script>
+    <script src="src/pages/algo-list.js" defer></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -109,17 +109,73 @@
     
     <script src="src/core/DataProvider.js"></script>
     <script src="src/pages/script.js"></script>
-    <script>
-  fetch('strategy-builder-component.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
-      const script = document.createElement('script');
-      script.src = 'src/pages/strategy-builder.js';
-      document.body.appendChild(script);
-    })
-    .catch(err => console.error('Không thể tải Strategy Builder:', err));
-</script>
+
+    <!-- Strategy Builder Panel -->
+    <div id="strategy-builder-panel" class="strategy-builder-panel" style="display: none;">
+        <div class="strategy-builder-header">
+            <h3>Strategy Builder</h3>
+            <button id="close-strategy-builder" class="close-btn">&times;</button>
+        </div>
+        <div class="strategy-builder-content">
+            <div class="strategy-name-section">
+                <label for="strategy-name">Tên chiến lược:</label>
+                <input type="text" id="strategy-name" placeholder="Nhập tên chiến lược..." value="SMA Crossover Strategy">
+            </div>
+
+            <div class="strategy-code-section">
+                <label for="strategy-code">Mã chứng khoán:</label>
+                <input type="text" id="strategy-code" placeholder="VD: FPT">
+            </div>
+
+            <div class="conditions-section">
+                <h4>Điều kiện mua (BUY):</h4>
+                <div id="buy-conditions" class="conditions-container">
+                    <div class="condition-item">
+                        <select class="condition-type">
+                            <option value="sma-crossover">SMA Crossover</option>
+                            <option value="rsi">RSI</option>
+                            <option value="price">Giá</option>
+                        </select>
+                        <div class="condition-params">
+                            <input type="number" class="param-input" placeholder="9" min="1" max="100">
+                            <span>cắt lên</span>
+                            <input type="number" class="param-input" placeholder="20" min="1" max="100">
+                        </div>
+                        <button class="remove-condition-btn">&times;</button>
+                    </div>
+                </div>
+                <button id="add-buy-condition" class="add-condition-btn">+ Thêm điều kiện</button>
+            </div>
+
+            <div class="conditions-section">
+                <h4>Điều kiện bán (SELL):</h4>
+                <div id="sell-conditions" class="conditions-container">
+                    <div class="condition-item">
+                        <select class="condition-type">
+                            <option value="sma-crossover">SMA Crossover</option>
+                            <option value="rsi">RSI</option>
+                            <option value="price">Giá</option>
+                        </select>
+                        <div class="condition-params">
+                            <input type="number" class="param-input" placeholder="9" min="1" max="100">
+                            <span>cắt xuống</span>
+                            <input type="number" class="param-input" placeholder="20" min="1" max="100">
+                        </div>
+                        <button class="remove-condition-btn">&times;</button>
+                    </div>
+                </div>
+                <button id="add-sell-condition" class="add-condition-btn">+ Thêm điều kiện</button>
+            </div>
+
+            <div class="strategy-actions">
+                <button id="test-strategy-btn" class="action-btn primary">Test Strategy</button>
+                <button id="save-strategy-btn" class="action-btn">Lưu Strategy</button>
+                <button id="load-strategy-btn" class="action-btn">Tải Strategy</button>
+            </div>
+        </div>
+    </div>
+
+    <script src="src/pages/strategy-builder.js" defer></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Inline Strategy Builder HTML in `algo-list.html` and `index.html` to avoid fetch failures that prevented the component from loading.
- Load Strategy Builder and Algo List scripts directly with `defer` so the builder is ready when buttons are clicked.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad7e19e5e08321a2c9cec175b2a2f6