### PR TITLE
Enable trendlines and indicators on algo view

### DIFF
--- a/algo-detail.html
+++ b/algo-detail.html
@@ -18,6 +18,13 @@
             <div class="ohlc-info"></div>
         </div>
         <div class="right-header">
+            <div class="indicator-menu">
+                <button class="tool-button" id="indicator-menu-btn">Chỉ báo</button>
+                <div class="indicator-dropdown" id="indicator-dropdown-content">
+                    <a href="#" data-indicator="ma">Moving Average</a>
+                    <a href="#" data-indicator="rsi">RSI (14)</a>
+                </div>
+            </div>
             <a href="algo-list.html" class="tool-button" id="back-to-list">Quay lại</a>
         </div>
     </header>
@@ -85,6 +92,7 @@
 <script src="src/tools/TrendLinePrimitive.js"></script>
 <script src="src/core/StrategyEngine.js"></script>
 <script src="src/core/DataProvider.js"></script>
+<script src="src/indicators/MAIndicator.js"></script>
 <script src="src/pages/algo-detail.js"></script>
 </body>
 </html>

--- a/src/pages/algo-detail.js
+++ b/src/pages/algo-detail.js
@@ -22,6 +22,20 @@ document.addEventListener('DOMContentLoaded', async function () {
 
     const strategyEngine = new StrategyEngine(chart, candleSeries);
 
+    const drawTrendLineBtn = document.getElementById('draw-trend-line-btn');
+    const indicatorMenuBtn = document.getElementById('indicator-menu-btn');
+    const indicatorDropdown = document.getElementById('indicator-dropdown-content');
+    const activeIndicators = {};
+
+    let drawingState = 'idle';
+    let trendLinePoints = [];
+    const drawnTrendLines = [];
+    let previewTrendLine = null;
+    let trendLineRedrawRequested = false;
+    let currentDrawingTarget = null;
+    let selectedTrendLine = null;
+    const moveState = { isMoving: false, targetLine: null, moveType: null, lastTime: null, lastPrice: null };
+
     // --- Lấy thông tin algo từ URL hoặc localStorage ---
     const params = new URLSearchParams(window.location.search);
     let algoName = params.get('name');
@@ -129,11 +143,14 @@ document.addEventListener('DOMContentLoaded', async function () {
     document.getElementById('overview-mdd').textContent = algo.mdd || '--%';
     document.getElementById('overview-profit').textContent = algo.profit || '--';
 
+    let history = [];
     // --- Tải dữ liệu lịch sử và thông tin công ty ---
-    const [history, companyName] = await Promise.all([
+    const [historyData, companyName] = await Promise.all([
         dataProvider.getHistory(algo.code, 'D'),
         dataProvider.getCompanyInfo(algo.code)
     ]);
+
+    history = historyData;
 
     if (descEl) descEl.textContent = companyName || '';
 
@@ -234,6 +251,240 @@ document.addEventListener('DOMContentLoaded', async function () {
     const markers = generateMarkers();
     candleSeries.setMarkers(markers);
 
+    // --- Indicator menu ---
+    if (indicatorMenuBtn && indicatorDropdown) {
+        indicatorMenuBtn.addEventListener('click', (event) => {
+            event.stopPropagation();
+            indicatorDropdown.classList.toggle('show');
+        });
+        document.addEventListener('click', (event) => {
+            if (!indicatorMenuBtn.contains(event.target)) {
+                indicatorDropdown.classList.remove('show');
+            }
+        });
+        indicatorDropdown.addEventListener('click', (event) => {
+            event.preventDefault();
+            const indicatorId = event.target.getAttribute('data-indicator');
+            if (!indicatorId) return;
+            if (indicatorId === 'ma') {
+                if (activeIndicators['ma']) {
+                    activeIndicators['ma'].remove();
+                    delete activeIndicators['ma'];
+                } else {
+                    const ma = new MAIndicator(chart, { period: 20, color: '#2962FF' });
+                    ma.addToChart(history);
+                    activeIndicators['ma'] = ma;
+                }
+            } else if (indicatorId === 'rsi') {
+                if (activeIndicators['rsi']) {
+                    chart.removeSeries(activeIndicators['rsi'].series);
+                    delete activeIndicators['rsi'];
+                } else {
+                    const rsiData = [];
+                    for (let i = 0; i < history.length; i++) {
+                        const rsi = strategyEngine.calculateRSI(history, i);
+                        if (rsi !== null) {
+                            rsiData.push({ time: history[i].time, value: rsi });
+                        }
+                    }
+                    const rsiSeries = chart.addLineSeries({
+                        priceScaleId: 'rsi',
+                        color: '#8884d8',
+                        lineWidth: 1,
+                        crosshairMarkerVisible: false,
+                        lastValueVisible: false
+                    });
+                    chart.priceScale('rsi').applyOptions({ scaleMargins: { top: 0.8, bottom: 0 } });
+                    rsiSeries.setData(rsiData);
+                    rsiSeries.createPriceLine({ price: 70, color: '#787B86', lineStyle: LightweightCharts.LineStyle.Dashed });
+                    rsiSeries.createPriceLine({ price: 30, color: '#787B86', lineStyle: LightweightCharts.LineStyle.Dashed });
+                    activeIndicators['rsi'] = { series: rsiSeries };
+                }
+            }
+            indicatorDropdown.classList.remove('show');
+        });
+    }
+
+    // --- Trend line drawing ---
+    function onChartMouseDown(event, target) {
+        const container = target.chart.chartElement().parentElement;
+        const bounds = container.getBoundingClientRect();
+        const x = event.clientX - bounds.left;
+        const y = event.clientY - bounds.top;
+
+        const time = target.chart.timeScale().coordinateToTime(x);
+        const price = target.series.coordinateToPrice(y);
+
+        if (!time || price === null) return;
+
+        const point = { time, price };
+
+        switch (drawingState) {
+            case 'idle':
+                let clickedLineInfo = null;
+                for (const line of drawnTrendLines) {
+                    const hitResult = line.primitive.hitTest(x, y);
+                    if (hitResult) {
+                        clickedLineInfo = { line, hitResult };
+                        break;
+                    }
+                }
+
+                if (selectedTrendLine && selectedTrendLine !== (clickedLineInfo ? clickedLineInfo.line : null)) {
+                    selectedTrendLine.primitive.setSelected(false);
+                    selectedTrendLine = null;
+                }
+
+                if (clickedLineInfo) {
+                    const { line } = clickedLineInfo;
+                    if (line !== selectedTrendLine) {
+                        line.primitive.setSelected(true);
+                        selectedTrendLine = line;
+                    }
+                    target.chart.applyOptions({ handleScroll: false, handleScale: false });
+                    drawingState = 'moving';
+                    moveState.isMoving = true;
+                    moveState.targetLine = line;
+                    moveState.moveType = clickedLineInfo.hitResult;
+                    moveState.lastTime = time;
+                    moveState.lastPrice = price;
+                }
+                break;
+            case 'activating_draw_mode':
+                trendLinePoints = [point];
+                currentDrawingTarget = target;
+                previewTrendLine = new TrendLine(target.chart, target.series, point, point);
+                target.series.attachPrimitive(previewTrendLine);
+                drawingState = 'placing_point_2';
+                break;
+            case 'placing_point_2':
+                if (target.chart !== currentDrawingTarget.chart) return;
+                previewTrendLine._p2 = point;
+                target.chart.priceScale('').applyOptions({});
+                drawnTrendLines.push({ targetId: target.id, primitive: previewTrendLine });
+                drawingState = 'idle';
+                drawTrendLineBtn.classList.remove('active');
+                trendLinePoints = [];
+                previewTrendLine = null;
+                currentDrawingTarget = null;
+                break;
+        }
+    }
+
+    function onCrosshairMoved(param) {
+        if (drawingState !== 'placing_point_2' || !param.point || !param.time || !currentDrawingTarget) return;
+        const price = currentDrawingTarget.series.coordinateToPrice(param.point.y);
+        if (price === null) return;
+        previewTrendLine._p2 = { time: param.time, price: price };
+        if (!trendLineRedrawRequested) {
+            trendLineRedrawRequested = true;
+            requestAnimationFrame(animationLoop);
+        }
+    }
+
+    function onChartMouseMove(event, target) {
+        if (drawingState !== 'moving' || !moveState.isMoving) return;
+        const container = target.chart.chartElement().parentElement;
+        const bounds = container.getBoundingClientRect();
+        const x = event.clientX - bounds.left;
+        const y = event.clientY - bounds.top;
+        const time = target.chart.timeScale().coordinateToTime(x);
+        const price = target.series.coordinateToPrice(y);
+        if (!time || price === null) return;
+        const line = moveState.targetLine.primitive;
+        const timeScale = target.chart.timeScale();
+        const p1Coord = timeScale.timeToCoordinate(line._p1.time);
+        const p2Coord = timeScale.timeToCoordinate(line._p2.time);
+        const lastTimeCoord = timeScale.timeToCoordinate(moveState.lastTime);
+        const p1Index = timeScale.coordinateToLogical(p1Coord);
+        const p2Index = timeScale.coordinateToLogical(p2Coord);
+        const lastTimeIndex = timeScale.coordinateToLogical(lastTimeCoord);
+        const currentTimeIndex = timeScale.coordinateToLogical(x);
+        if (p1Index === null || p2Index === null || lastTimeIndex === null || currentTimeIndex === null) return;
+        const timeDiff = currentTimeIndex - lastTimeIndex;
+        const priceDiff = price - moveState.lastPrice;
+        switch (moveState.moveType) {
+            case 'line':
+                const newP1Time = timeScale.logicalToTime(p1Index + timeDiff);
+                const newP2Time = timeScale.logicalToTime(p2Index + timeDiff);
+                if (newP1Time) line._p1.time = newP1Time;
+                if (newP2Time) line._p2.time = newP2Time;
+                line._p1.price += priceDiff;
+                line._p2.price += priceDiff;
+                break;
+            case 'p1':
+                line._p1.time = time;
+                line._p1.price = price;
+                break;
+            case 'p2':
+                line._p1.time = time;
+                line._p1.price = price;
+                break;
+        }
+        moveState.lastTime = time;
+        moveState.lastPrice = price;
+        target.chart.priceScale('').applyOptions({});
+    }
+
+    function onChartMouseUp(event, target) {
+        if (drawingState === 'moving' && moveState.isMoving) {
+            target.chart.applyOptions({ handleScroll: true, handleScale: true });
+            drawingState = 'idle';
+            moveState.isMoving = false;
+            moveState.targetLine = null;
+            moveState.moveType = null;
+            moveState.lastTime = null;
+            moveState.lastPrice = null;
+        }
+    }
+
+    function handleKeyDown(event) {
+        if ((event.key === 'Delete' || event.key === 'Backspace') && selectedTrendLine) {
+            candleSeries.detachPrimitive(selectedTrendLine.primitive);
+            const index = drawnTrendLines.findIndex(line => line.primitive === selectedTrendLine.primitive);
+            if (index > -1) drawnTrendLines.splice(index, 1);
+            selectedTrendLine = null;
+            chart.priceScale('').applyOptions({});
+        }
+    }
+
+    function animationLoop() {
+        if (trendLineRedrawRequested) {
+            if (drawingState === 'placing_point_2' && currentDrawingTarget && currentDrawingTarget.chart) {
+                currentDrawingTarget.chart.priceScale('').applyOptions({});
+            }
+            trendLineRedrawRequested = false;
+        }
+    }
+
+    drawTrendLineBtn.addEventListener('click', (event) => {
+        if (drawingState === 'idle') {
+            drawingState = 'activating_draw_mode';
+            drawTrendLineBtn.classList.add('active');
+            if (selectedTrendLine) {
+                selectedTrendLine.primitive.setSelected(false);
+                selectedTrendLine = null;
+            }
+        } else {
+            drawingState = 'idle';
+            drawTrendLineBtn.classList.remove('active');
+            if (previewTrendLine && currentDrawingTarget) {
+                currentDrawingTarget.series.detachPrimitive(previewTrendLine);
+            }
+            previewTrendLine = null;
+            currentDrawingTarget = null;
+        }
+        event.currentTarget.blur();
+    });
+
+    const chartContainer = document.getElementById('main-chart-container');
+    const mainChartTarget = { chart, series: candleSeries, id: 'main' };
+    chartContainer.addEventListener('mousedown', (e) => onChartMouseDown(e, mainChartTarget));
+    chartContainer.addEventListener('mousemove', (e) => onChartMouseMove(e, mainChartTarget));
+    chartContainer.addEventListener('mouseup', (e) => onChartMouseUp(e, mainChartTarget));
+    chartContainer.addEventListener('mouseleave', (e) => onChartMouseUp(e, mainChartTarget));
+    chart.subscribeCrosshairMove(onCrosshairMoved);
+    window.addEventListener('keydown', handleKeyDown);
 
 });
 


### PR DESCRIPTION
## Summary
- add indicator dropdown and MA script to algo detail page
- implement trendline drawing logic and indicator toggling in algo detail script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68add4743b9c83218150c67afd597bf6